### PR TITLE
fix. 新浪网新闻列表误杀

### DIFF
--- a/NoAppDownload.txt
+++ b/NoAppDownload.txt
@@ -788,7 +788,6 @@ sina.cn##.fl_suspension_box
 sina.cn##.j_relevent_video.s_card
 sina.cn##.j_wbrecommend_wrap.j_article_relevent.s_card
 sina.cn###j_card_miniVideo
-sina.cn##.look_more_a, .j_callST
 sina.cn#?#.m_f_a_r:-abp-contains(打开APP)
 sina.cn##.plague_Card, .index
 sina.cn##.popGo.ok


### PR DESCRIPTION
```adblock
sina.cn##.look_more_a, .j_callST
```

被拦截后
![45ae240ca7b833a62510ae4a121a0f3](https://github.com/Noyllopa/NoAppDownload/assets/126886178/fddc5136-6cdf-413d-a713-58da99288655)
正常情况
![9591bcdb72bc70bc1cdf180e0169a58](https://github.com/Noyllopa/NoAppDownload/assets/126886178/bb35339c-2aa4-4595-89d1-7b0641a28d1e)

由 @damengzhu 发现